### PR TITLE
Patch: Clean up underlying data except for incremental tables with `append` strategy

### DIFF
--- a/dbt/include/athena/macros/adapters/relation.sql
+++ b/dbt/include/athena/macros/adapters/relation.sql
@@ -1,5 +1,5 @@
 {% macro athena__drop_relation(relation) -%}
-  {% if config.get('incremental_strategy') == 'insert_overwrite' %}
+  {% if config.get('incremental_strategy') != 'append' %}
     {%- do adapter.clean_up_table(relation.schema, relation.table) -%}
   {% endif %}
   {% call statement('drop_relation', auto_begin=False) -%}


### PR DESCRIPTION
https://github.com/Tomme/dbt-athena/pull/73

models materialized as `table` fail to create because of the `HIVE_PATH_ALREADY_EXISTS` error from Athena.